### PR TITLE
Use faster canvas reset method

### DIFF
--- a/code.js
+++ b/code.js
@@ -64,6 +64,10 @@ const rect = (ctx, stroke, color, x, y, w, h) => {
     }
 };
 
+const clearRect = (ctx, x, y, w, h) => {
+    ctx.clearRect(x, y, w, h);
+};
+
 const text = (ctx, stroke, color, font, text, x, y) => {
     ctx.font = font;
     if (!stroke) {
@@ -129,7 +133,7 @@ const main = () => {
             setTriangle();
         }
 
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        clearRect(ctx, 0, 0, canvas.width, canvas.height);
 
         // Create point pairs beforehand
         const pointPairs = permute(points);

--- a/code.js
+++ b/code.js
@@ -53,6 +53,7 @@ const circle = (ctx, type, color, radius, p) => {
     });
 };
 
+// Not used currently
 const rect = (ctx, stroke, color, x, y, w, h) => {
     if (!stroke) {
         ctx.fillStyle = color;
@@ -128,7 +129,7 @@ const main = () => {
             setTriangle();
         }
 
-        rect(ctx, false, "white", 0, 0, canvas.width, canvas.height);
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
 
         // Create point pairs beforehand
         const pointPairs = permute(points);

--- a/page.html
+++ b/page.html
@@ -2,6 +2,6 @@
 <body>
 <canvas id="canvas"></canvas>
 <script src="code.js"></script>
-<link rel="stylesheet" href="style.css"></link>
+<link rel="stylesheet" href="style.css"/>
 </body>
 </html>


### PR DESCRIPTION
Instead of drawing a rect over the canvas, you can use clearRect to clear the canvas.

Not benchmarked, but should be faster.